### PR TITLE
Clean up dependency specification

### DIFF
--- a/AC_tools/AC_time.py
+++ b/AC_tools/AC_time.py
@@ -17,11 +17,13 @@ import time
 import calendar
 import datetime as datetime
 from datetime import datetime as datetime_
+import sys
 # Attempt to import ephem if installed
-try:
-    import ephem
-except ImportError:
-    print('ephem package not installed')
+if sys.version_info.major < 3:
+    try:
+        import ephem
+    except ImportError:
+        print('ephem package not installed')
 
 
 def get_day_fraction(date):

--- a/AC_tools/GEOSChem_bpch.py
+++ b/AC_tools/GEOSChem_bpch.py
@@ -33,10 +33,11 @@ import pandas as pd
 import xarray as xr
 import re
 from netCDF4 import Dataset
-try:
-    import iris
-except ImportError:
-    print('WARNING iris not imported')
+if sys.version_info.major < 3:
+    try:
+        import iris
+    except ImportError:
+        print('WARNING iris not imported')
 import logging
 # Math/Analysis
 import numpy as np

--- a/AC_tools/obsolete/plotting_REDUNDANT.py
+++ b/AC_tools/obsolete/plotting_REDUNDANT.py
@@ -9,11 +9,13 @@ Notes
  - These functions are a mixture fo those made redundant by shift from matplotlib's basemap to cartopy and those that are now longer in use/years old/not useful/not pythonic
 
 """
+import sys
 # - Required modules:
-try:
-    from mpl_toolkits.basemap import Basemap
-except ModuleNotFoundError:
-    print('WARNING: Module not found error raised for: mpl_toolkits.basemap')
+if sys.version_info.major < 3:
+    try:
+        from mpl_toolkits.basemap import Basemap
+    except ModuleNotFoundError:
+        print('WARNING: Module not found error raised for: mpl_toolkits.basemap')
 import matplotlib.pyplot as plt
 import matplotlib as mpl
 from pylab import setp

--- a/AC_tools/plotting.py
+++ b/AC_tools/plotting.py
@@ -10,10 +10,12 @@ NOTE(S):
  - Where external code is used credit is given.
 """
 # - Required modules:
-try:
-    from mpl_toolkits.basemap import Basemap
-except ModuleNotFoundError:
-    print('WARNING: Module not found error raised for: mpl_toolkits.basemap')
+import sys
+if sys.version_info.major < 3:
+    try:
+        from mpl_toolkits.basemap import Basemap
+    except ModuleNotFoundError:
+        print('WARNING: Module not found error raised for: mpl_toolkits.basemap')
 import matplotlib.pyplot as plt
 import matplotlib as mpl
 from pylab import setp

--- a/Scripts/bpch2netCDF.py
+++ b/Scripts/bpch2netCDF.py
@@ -13,10 +13,11 @@ import sys
 import glob
 import os
 import netCDF4
-try:
-    import iris
-except ImportError:
-    print('WARNING iris not imported')
+if sys.version_info.major < 3:
+    try:
+        import iris
+    except ImportError:
+        print('WARNING iris not imported')
 # retain back compatibility for PyGChem
 try:
     if (sys.version_info.major <= 2):

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,18 @@
+name: ac_tools
+channels:
+    - conda-forge
+dependencies:
+    - python=3.7
+    - affine
+    - cartopy
+    - geopandas
+    - geos
+    - matplotlib
+    - netcdf4
+    - numpy
+    - pandas
+    - proj4
+    - pytest
+    - rasterio
+    - scipy
+    - xarray

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,19 @@ on_rtd = os.environ.get('READTHEDOCS') == 'True'
 if on_rtd:
     INSTALL_REQUIRES = []
 else:
-    INSTALL_REQUIRES = ['pandas', 'xarray', 'numpy', 'scipy', 'pytest']
+    INSTALL_REQUIRES = [
+                        'affine',
+                        'cartopy',
+                        'geopandas',
+                        'matplotlib',
+                        'netcdf4',
+                        'numpy',
+                        'pandas',
+                        'pytest',
+                        'rasterio',
+                        'scipy',
+                        'xarray'
+                       ]
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
This commit adds three things:

    * a minimal conda environment spec for AC_tools, in
      environment.yaml
    * version-specific module import conditions for modules that are only
      relevant for now-deprecated Python 2 AC_tools content (preventing
      import failure warning messages from appearing in Python 3
      environments)
    * additional `install_requires` dependencies to correctly reflect
      minimal project requirements