### PR TITLE
New KPP functions for Heterogeneous reactions

### DIFF
--- a/AC_tools/KPP.py
+++ b/AC_tools/KPP.py
@@ -521,6 +521,8 @@ def get_dicts_of_KPP_eqn_file_reactions(folder=None, filename=None,
         #   'NIT', 'PAN', 'ALK', 'EPO',
         'ARRPLUS', 'TUNPLUS',
         '1.33E-13+3.82E-11*exp',  # Why is this function not in gckpp.kpp?
+        #New Specist functions for Hetrogeneous 
+        'uptk','ByAcid','K_MT','K_CLD',
     )
     # Loop lines in file
     with open(folder+filename, 'r') as file_:


### PR DESCRIPTION
The latest version of GEOS-Chem has new KPP functions for the Heterogeneous reactions and reactions previously in sulfate_mod.F90.

 This commit adds some new strings to the list to of existing KPP functions in get_dicts_of_KPP_eqn_file_reactions so that it is still able to split fullchem.eqn for tagging of reactions. Tested with fullchem.eqn from 14.0.0